### PR TITLE
feat(swagger): use HTTPS when using swagger on remote server

### DIFF
--- a/server/src/main/java/com/battlecruisers/yanullja/YanulljaApplication.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/YanulljaApplication.java
@@ -1,15 +1,18 @@
 package com.battlecruisers.yanullja;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server Url")})
 public class YanulljaApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(YanulljaApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(YanulljaApplication.class, args);
+    }
 
 }


### PR DESCRIPTION
스웨거가 리모트 서버에서 http를 사용하기 때문에

```
Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure resource '<URL>'. This request has been blocked; the content must be served over HTTPS.
```

위 에러가 나던 현상을 고쳤습니다.

여러 블로그글들을 보면 swagger v2 기준으로 되어있기 때문에 맞지 않고,

https://stackoverflow.com/questions/70843940/springdoc-openapi-ui-how-do-i-set-the-request-to-https

위 링크 글을 참고했습니다. 

closes #80

cors가 문제가 아니라 swagger 설정 문제였습니다.