### PR TITLE
feat(Member/*): support AuthenticatedPrincipal

### DIFF
--- a/server/src/main/java/com/battlecruisers/yanullja/common/security/MockUserDetailsService.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/common/security/MockUserDetailsService.java
@@ -2,8 +2,8 @@ package com.battlecruisers.yanullja.common.security;
 
 import com.battlecruisers.yanullja.member.MemberRepository;
 import com.battlecruisers.yanullja.member.domain.Member;
+import com.battlecruisers.yanullja.member.domain.SecurityMember;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,9 +20,7 @@ public class MockUserDetailsService implements UserDetailsService {
         throws UsernameNotFoundException {
         Member member = memberRepository.findByProviderId(username)
             .orElseThrow(() -> new RuntimeException("Provider Id not found!"));
-        return User.builder()
-            .username(member.getProviderId())
-            .password(member.getProvider())
-            .build();
+
+        return new SecurityMember(member);
     }
 }

--- a/server/src/main/java/com/battlecruisers/yanullja/coupon/MemberCouponController.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/coupon/MemberCouponController.java
@@ -3,11 +3,11 @@ package com.battlecruisers.yanullja.coupon;
 import com.battlecruisers.yanullja.coupon.dto.MemberCouponDto;
 import com.battlecruisers.yanullja.coupon.dto.MemberCouponRegisterDto;
 import com.battlecruisers.yanullja.coupon.dto.MemberCouponResponseDto;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import com.battlecruisers.yanullja.member.domain.SecurityMember;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,20 +25,18 @@ public class MemberCouponController {
     private final MemberCouponService memberCouponService;
 
     @GetMapping
-    public List<MemberCouponResponseDto> getMemberCoupons() {
-        final Long memberId = 1L;
+    public List<MemberCouponResponseDto> getMemberCoupons(
+        @AuthenticationPrincipal
+        SecurityMember me) {
+        var memberId = me.getId();
         return memberCouponService.findMemberCouponsWithCoupon(memberId);
     }
 
     @PostMapping("")
     // 회원이 쿠폰 등록
     public void register(@RequestBody MemberCouponRegisterDto dto,
-        HttpServletRequest request) {
-        // 세션에서 회원 아이디 추출
-        HttpSession session = request.getSession();
-//        Long memberId = (Long) session.getAttribute("id");
-        Long memberId = 1L;
-
+        @AuthenticationPrincipal SecurityMember me) {
+        var memberId = me.getId();
         memberCouponService.register(dto.getCouponId(), memberId);
     }
 
@@ -48,16 +46,12 @@ public class MemberCouponController {
 
     // 회원이 사용한 쿠폰 내역 조회
     @GetMapping("/usage-history")
-    public List<MemberCouponDto> history(HttpServletRequest request) {
-        // 세션에서 회원 아이디 추출
-        HttpSession session = request.getSession();
-//        Long memberId = (Long) session.getAttribute("id");
-
-        Long memberId = 1L;
+    public List<MemberCouponDto> history(
+        @AuthenticationPrincipal SecurityMember me) {
+        var memberId = me.getId();
         // 사용내역 반환
         List<MemberCouponDto> histories = memberCouponService.getUsageHistory(
             memberId);
-
         return histories;
     }
 
@@ -72,10 +66,13 @@ public class MemberCouponController {
     // 특정 숙소에서 사용 가능한 쿠폰 조회
     @GetMapping("/{roomId}")
     public List<MemberCouponDto> room(
-        @PathVariable(name = "roomId") Long roomId) {
+        @PathVariable(name = "roomId") Long roomId,
+        @AuthenticationPrincipal SecurityMember me) {
 //        Pageable pageable = PageRequest.of(page, size);
+
+        var memberId = me.getId();
         List<MemberCouponDto> memberCouponDtos = memberCouponService.getRoomCoupons(
-            roomId, 1L);
+            roomId, memberId);
         return memberCouponDtos;
     }
 

--- a/server/src/main/java/com/battlecruisers/yanullja/member/MemberController.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/member/MemberController.java
@@ -1,9 +1,10 @@
 package com.battlecruisers.yanullja.member;
 
-import com.battlecruisers.yanullja.member.domain.Member;
+import com.battlecruisers.yanullja.member.domain.SecurityMember;
+import com.battlecruisers.yanullja.member.dto.MemberResponseDto;
 import com.battlecruisers.yanullja.member.dto.MemberUpdateDto;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,16 +19,18 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public Member getMyInfo() {
-        var memberId = 1L;
+    public MemberResponseDto getMyInfo(
+        @AuthenticationPrincipal SecurityMember me) {
+
+        var memberId = me.getId();
         return memberService.getMember(memberId);
     }
 
     @PutMapping("/me")
-    public Member updateMyInfo(@Valid @RequestBody Member member,
+    public void updateMyInfo(@AuthenticationPrincipal SecurityMember member,
         @RequestBody MemberUpdateDto dto) {
-        var memberId = 1L;
-        return memberService.updateMember(memberId, dto);
+        var memberId = member.getId();
+        memberService.updateMember(memberId, dto);
     }
 
 }

--- a/server/src/main/java/com/battlecruisers/yanullja/member/MemberService.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.battlecruisers.yanullja.member;
 
 import com.battlecruisers.yanullja.member.domain.Member;
+import com.battlecruisers.yanullja.member.dto.MemberResponseDto;
 import com.battlecruisers.yanullja.member.dto.MemberUpdateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,12 +14,12 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public Member getMember(Long memberId) {
+    public MemberResponseDto getMember(Long memberId) {
         var member = memberRepository.findById(memberId)
             .orElseThrow(
                 () -> new MemberNotFoundException(memberId)
             );
-        return member;
+        return MemberResponseDto.from(member);
     }
 
     @Transactional

--- a/server/src/main/java/com/battlecruisers/yanullja/member/domain/SecurityMember.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/member/domain/SecurityMember.java
@@ -1,0 +1,24 @@
+package com.battlecruisers.yanullja.member.domain;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+@Setter
+public class SecurityMember extends User implements Serializable {
+
+    private Long id;
+    private String provider;
+    private String providerId;
+
+    public SecurityMember(Member member) {
+        super(member.getProviderId(), member.getProvider(), List.of());
+        this.id = member.getId();
+        this.provider = member.getProvider();
+        this.providerId = member.getProviderId();
+    }
+
+}

--- a/server/src/main/java/com/battlecruisers/yanullja/member/dto/MemberResponseDto.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/member/dto/MemberResponseDto.java
@@ -1,0 +1,40 @@
+package com.battlecruisers.yanullja.member.dto;
+
+import com.battlecruisers.yanullja.member.domain.Member;
+import lombok.Data;
+
+@Data
+public class MemberResponseDto {
+
+    private Long id;
+    private String provider;
+    private String providerId;
+    private String email;
+    private String nickName;
+    private String phoneNumber;
+
+    public MemberResponseDto(
+        Long id,
+        String provider,
+        String providerId,
+        String email,
+        String nickName,
+        String phoneNumber) {
+        this.id = id;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.email = email;
+        this.nickName = nickName;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public static MemberResponseDto from(Member member) {
+        return new MemberResponseDto(
+            member.getId(),
+            member.getProvider(),
+            member.getProviderId(),
+            member.getEmail(),
+            member.getNickName(),
+            member.getPhoneNumber());
+    }
+}

--- a/server/src/main/java/com/battlecruisers/yanullja/reservation/ReservationController.java
+++ b/server/src/main/java/com/battlecruisers/yanullja/reservation/ReservationController.java
@@ -1,5 +1,6 @@
 package com.battlecruisers.yanullja.reservation;
 
+import com.battlecruisers.yanullja.member.domain.SecurityMember;
 import com.battlecruisers.yanullja.reservation.dto.ReservationCancelRequestDto;
 import com.battlecruisers.yanullja.reservation.dto.ReservationRequestDto;
 import com.battlecruisers.yanullja.reservation.dto.ReservationResponseDto;
@@ -9,12 +10,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -27,8 +28,10 @@ public class ReservationController {
 
     @GetMapping
     @Operation(summary = "결제 로직 조회")
-    public ResponseEntity reservationsByMemberId(@RequestParam Long memberId) {
-        Long mockMemberId = 1L;
+    public ResponseEntity<List<ReservationResultDto>> reservationsByMemberId(
+        @AuthenticationPrincipal SecurityMember me
+    ) {
+        var memberId = me.getId();
 
         List<ReservationResultDto> results = reservationService.getReservationsByMemberId(
             memberId);
@@ -38,13 +41,15 @@ public class ReservationController {
 
     @PostMapping("/instant")
     @Operation(summary = "예약 및 결제")
-    public ResponseEntity reserve(
-        @RequestBody ReservationRequestDto reservationRequestDto) {
+    public ResponseEntity<ReservationResponseDto> reserve(
+        @RequestBody ReservationRequestDto reservationRequestDto,
+        @AuthenticationPrincipal SecurityMember me
+    ) {
         log.info("ReservationController 호출 됨");
         log.info("ReservationController reservationRequestDto = {}",
             reservationRequestDto);
         //todo 스프링 시큐리티 멤버로직 추가
-        Long mockMemberId = 1L;
+        Long mockMemberId = me.getId();
         ReservationResponseDto reservationResponseDto = reservationService.reserve(
             reservationRequestDto, mockMemberId);
 
@@ -53,7 +58,7 @@ public class ReservationController {
 
     @DeleteMapping
     @Operation(summary = "예약 및 결제 취소")
-    public ResponseEntity cancel(
+    public ResponseEntity<Void> cancel(
         @RequestBody ReservationCancelRequestDto cancelDto) {
         reservationService.cancel(cancelDto);
 


### PR DESCRIPTION
로그인을 할 때, MemberRepository에서 Member를 가져와, 그 중 몇몇 중요한 정보들을
SecurityMember에 저장하고 이를 레디스에 저장합니다.

참고: SecurityMember는 Security의 User를 상속합니다.

추후 로그인이 필요한 요청을 할 때, 디비에 직접 접근할 필요 없이 레디스에서 memberId와 같은 정보를 가져와 바로 사용할 수 있습니다.

@AuthenticatedPrincipal SecurityMember me

위 인자를 컨트롤러에서 사용하면, me.getId 로 id를 얻어올 수 있습니다.